### PR TITLE
TemporaryResources context manager to enable using non-global, custom css and js in a Template

### DIFF
--- a/panel_components/resources.py
+++ b/panel_components/resources.py
@@ -1,0 +1,155 @@
+"""This Module contains the TemporaryResources context manager
+
+The purpose of the TemporaryResources context manager is to enable using temporary, specific
+configuration of resources when creating a custom Template.
+
+If you use the global configuration `pn.config` for your templates you will include the same
+css and js files in all templates. This is problematic if you want different templates, like for
+example a light template, a dark template, a bootstrap template, a material template, a template
+with Plotly Plots, and template without Plotly plots etc."""
+from typing import Callable, Dict, List, Optional, Set
+
+import panel as pn
+from bokeh.model import Model
+
+EXTENSIONS = {**pn.extension._imports}  # pylint: disable=protected-access
+
+
+class TemporaryResources:  # pylint: disable=(too-many-instance-attributes
+    """The purpose of the TemporaryResources context manager is to enable using temporary, specific
+    configuration of resources when creating a custom Template.
+
+    If you use the global configuration `pn.config` for your templates you will include the same
+    css and js files in all templates. This is problematic if you want different templates, like for
+    example a light template, a dark template, a bootstrap template, a material template, a template
+    with Plotly Plots, and template without Plotly plots etc."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        extensions: Optional[Set] = None,
+        raw_css: Optional[List] = None,
+        css_files: Optional[List] = None,
+        js_files: Optional[Dict] = None,
+        include_panel_css: bool = True,
+    ):
+        """The purpose of the TemporaryResources context manager is to enable using temporary,
+        specific configuration of resources when creating a custom Template.
+
+        If you use the global configuration `pn.config` for your templates you will include the same
+        css and js files in all templates. This is problematic if you want different templates,
+        like for example a light template, a dark template, a bootstrap template, a material
+        template, a template with Plotly Plots, and template without Plotly plots etc.
+
+        Args:
+            extensions (Optional[Set], optional): Custom pn.extensions like. For example {'plotly'}.
+                Defaults to None.
+            raw_css (Optional[List], optional): Corresponds to pn.config.raw_css.
+                Defaults to None.
+            css_files (Optional[List], optional): Corresponds to pn.config.css_files.
+                Defaults to None.
+            js_files (Optional[Dict], optional): Corresponds to pn.js_files. Defaults to None.
+            include_panel_css (bool, optional): If False the Panel css is not included. You can use
+                this if you wan't to create static pages without Panel functionality. The page will
+                load quicker if the Panel css is not included, Defaults to True.
+
+        >>> pn.config.raw_css = ["body {color: black}"]
+        >>> with TemporaryResources(raw_css=["body {color: white}"]):
+        ...     temporary_raw_css = pn.config.raw_css
+        ...     temporary_header = pn.io.resources.Resources().render()
+        >>> temporary_raw_css
+        ['body {color: white}']
+        >>> pn.config.raw_css
+        ['body {color: black}']
+        >>> "body {color: white}" in temporary_header
+        True
+
+        Please note that the `pn.io.resources.Resources().render` function is what is normally
+        used by Bokeh and Panel to render the resources (css+js) in the head of the template. Thus
+        by using the TemporaryResources context manager we can get specific resources in the head
+        of the template only."""
+        super().__init__()
+
+        self._extensions = extensions or set()
+        self._raw_css = raw_css or []
+        self._css_files = css_files or []
+        self._js_files = js_files or {}
+        self._include_panel_css = include_panel_css
+
+        self._backup_raw_css = pn.config.raw_css
+        self._backup_css_files = pn.config.css_files
+        self._backup_js_files = pn.config.js_files
+        self._backup_model_class_reverse_map = Model.model_class_reverse_map
+
+    def __enter__(self):
+        if self._extensions:
+            pn.extension(*self._extensions)
+
+        pn.config.raw_css = self._raw_css
+        pn.config.js_files = self._js_files
+        pn.config.css_files = [*self._panel_css_files, *self._css_files]
+        exclude_extension = self._get_exclude_extension_func(self._extensions)
+        Model.model_class_reverse_map = {
+            name: model
+            for name, model in self._backup_model_class_reverse_map.items()
+            if not exclude_extension(name)
+        }
+
+    def __exit__(self, type, value, traceback):  # pylint: disable=redefined-builtin
+        Model.model_class_reverse_map = self._backup_model_class_reverse_map
+        pn.config.css_files = self._backup_css_files
+        pn.config.js_files = self._backup_js_files
+        pn.config.raw_css = self._backup_raw_css
+
+    @property
+    def _panel_css_files(self) -> List[str]:
+        return [
+            file
+            for file in self._backup_css_files
+            if self._is_panel_style_file(file) and self._include_panel_css
+        ]
+
+    @staticmethod
+    def _is_panel_style_file(file: str) -> bool:
+        if "panel\\_styles" in file:
+            return True
+        if "panel/_styles" in file:
+            return True
+        return False
+
+    @staticmethod
+    def _get_exclude_extension_func(extensions: Optional[Set] = None) -> Callable:
+        """Returns a function that can determine whether the given model/ extension
+        should be included in the temporary list of models/ extensions.
+
+        Args:
+            extensions (Optional[Set], optional): [description]. Defaults to None.
+
+        Returns:
+            Callable: [description]
+        """
+        if extensions is None:
+            extensions = set()
+        extensions_to_exclude = [v for k, v in EXTENSIONS.items() if k not in extensions]
+
+        def exclude_extension(model: str) -> bool:
+            """Returns whether the given model/ extension
+            should be included in the temporary list of models/ extensions.
+
+            I.e. if the model is a Bokeh extension (like Panels DeckGl extension) that is not in
+            the specified extensions. Then it should not be included.
+
+            Args:
+                model (str): Name of a (module of a) model. For example 'panel.models.deckgl'.
+
+            Returns:
+                bool: True if the model should be included. False otherwise.
+            """
+            model_str = model
+            if not "." in model_str or "bokeh." in model_str:
+                return False
+            for extension in extensions_to_exclude:
+                if extension in model_str:
+                    return True
+            return False
+
+        return exclude_extension

--- a/panel_components/resources.py
+++ b/panel_components/resources.py
@@ -124,10 +124,11 @@ class TemporaryResources:  # pylint: disable=(too-many-instance-attributes
         should be included in the temporary list of models/ extensions.
 
         Args:
-            extensions (Optional[Set], optional): [description]. Defaults to None.
+            extensions (Optional[Set], optional): A set of temporary extensions. For example
+                {"katex", "deckgl"}. Defaults to None.
 
         Returns:
-            Callable: [description]
+            Callable: A function `exclude_extension(model: str) -> bool`.
         """
         if extensions is None:
             extensions = set()

--- a/panel_components/resources.py
+++ b/panel_components/resources.py
@@ -62,8 +62,8 @@ class TemporaryResources:  # pylint: disable=(too-many-instance-attributes
         ['body {color: black}']
         >>> "body {color: white}" in temporary_header
         True
-        >>> "body {color: black}" not in temporary_header
-        True
+        >>> "body {color: black}" in temporary_header
+        False
 
         Please note that the `pn.io.resources.Resources().render` function is what is normally
         used by Bokeh and Panel to render the resources (css+js) in the head of the template. Thus

--- a/panel_components/resources.py
+++ b/panel_components/resources.py
@@ -32,7 +32,7 @@ class TemporaryResources:  # pylint: disable=(too-many-instance-attributes
         js_files: Optional[Dict] = None,
         include_panel_css: bool = True,
     ):
-        """The purpose of the TemporaryResources context manager is to enable using temporary,
+        """The purpose of the `TemporaryResources` context manager is to enable using temporary,
         specific configuration of resources when creating a custom Template.
 
         If you use the global configuration `pn.config` for your templates you will include the same
@@ -61,6 +61,8 @@ class TemporaryResources:  # pylint: disable=(too-many-instance-attributes
         >>> pn.config.raw_css
         ['body {color: black}']
         >>> "body {color: white}" in temporary_header
+        True
+        >>> "body {color: black}" not in temporary_header
         True
 
         Please note that the `pn.io.resources.Resources().render` function is what is normally

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,187 @@
+"""The purpose of this module is to test the TemporaryResources context manager
+
+The purpose of the TemporaryResources context manager is to enable using temporary, specific
+configuration of resources when creating a custom Template.
+
+If you use the global configuration `pn.config` for your templates you will include the same
+css and js files in all templates. This is problematic if you want different templates, like for
+example a light template, a dark template, a bootstrap template, a material template, a template
+with Plotly Plots, a template without Plotly plots etc.
+"""
+import panel as pn
+import pytest
+from panel_components.resources import TemporaryResources
+# pylint: disable=missing-function-docstring
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_config_except_panel_css():
+    """Reset pn.config except for panel css"""
+    # pylint: disable=protected-access
+    pn.config.raw_css = []
+    pn.config.js_files = {}
+    pn.config.css_files = [
+        file for file in pn.config.css_files if TemporaryResources._is_panel_style_file(file)
+    ]
+
+
+@pytest.fixture()
+def clear_config():
+    """Reset pn.config"""
+    pn.config.raw_css = []
+    pn.config.js_files = {}
+    pn.config.css_files = []
+
+
+def _contains_bokeh_and_panel_resources(text):
+    return (
+        "bokeh-" in text
+        and "bokeh-widgets" in text
+        and "bokeh-tables" in text
+        and ".panel-widget-box"
+    )
+
+
+def test_does_not_include_pn_config_raw_css():
+    # Given
+    pre_raw_css = "body {background: black;"
+
+    # When
+    pn.config.raw_css.append(pre_raw_css)
+    backup = pn.config.raw_css
+
+    with TemporaryResources():
+        text = pn.io.resources.Resources().render()
+
+    # Then
+    assert pre_raw_css not in text
+    assert pn.config.raw_css == backup
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_does_not_include_pn_config_css_files():
+    # Given
+    pre_css_file = "https://somedomain.com/test.css"
+
+    # When
+    pn.config.css_files.append(pre_css_file)
+    backup = pn.config.css_files
+    with TemporaryResources():
+        text = pn.io.resources.Resources().render()
+
+    # Then
+    assert pre_css_file not in text
+    assert pn.config.css_files == backup
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_does_not_include_pn_config_js_files():
+    # Given
+    pre_js = "http://some/domain.com/test.js"
+
+    # When
+    pn.config.js_files = {"somejs": pre_js}
+    backup = pn.config.js_files
+    with TemporaryResources():
+        text = pn.io.resources.Resources().render()
+
+    # Then
+    assert pre_js not in text
+    assert pn.config.js_files == backup
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_does_not_include_pn_extension():
+    # Given
+    pre_extension = "plotly"
+
+    # When
+    pn.extension(pre_extension)
+    with TemporaryResources():
+        text = pn.io.resources.Resources().render()
+
+    # Then
+    assert pre_extension not in text
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_includes_template_extension():
+    extension = "katex"
+
+    with TemporaryResources(extensions={extension}):
+        text = pn.io.resources.Resources().render()
+
+    assert extension in text
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_includes_template_raw_css():
+    raw_css = "body {background: black;"
+
+    with TemporaryResources(raw_css=[raw_css]):
+        text = pn.io.resources.Resources().render()
+
+    assert raw_css in text
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_includes_template_css_files():
+    css_file = "https://somedomain.com/test.css"
+
+    with TemporaryResources(css_files=[css_file]):
+        text = pn.io.resources.Resources().render()
+
+    assert css_file in text
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_includes_template_js_files():
+    js_file = "http://some/domain.com/test.js"
+
+    with TemporaryResources(js_files={"somejs": js_file}):
+        text = pn.io.resources.Resources().render()
+
+    assert js_file in text
+    assert _contains_bokeh_and_panel_resources(text)
+
+
+def test_can_exclude_panel_css():
+    with TemporaryResources(include_panel_css=False):
+        text = pn.io.resources.Resources().render()
+
+    assert ".panel-widget-box" not in text
+
+
+def test_complex_use_case():
+    # Given
+    pre_raw_css = "body {background: black;"
+    pre_css_file = "https://somedomain.com/test.css"
+    pre_js = "http://some/domain.com/test.js"
+    pre_extension = "plotly"
+
+    extension = "katex"
+
+    # When
+    pn.extension(pre_extension)
+    pn.config.raw_css.append(pre_raw_css)
+    pn.config.css_files.append(pre_css_file)
+    pn.config.js_files = {"somejs": pre_js}
+    backup_css_files = pn.config.css_files
+
+    with TemporaryResources(extensions={extension}, include_panel_css=False):
+        text = pn.io.resources.Resources().render()
+
+    # Then
+    assert "bokeh-" in text
+    assert "bokeh-widgets" in text
+    assert "bokeh-tables" in text
+    assert ".panel-widget-box" not in text
+    assert extension in text
+
+    assert pre_raw_css not in text
+    assert pre_css_file not in text
+    assert pre_js not in text
+    assert pre_extension not in text
+
+    assert pn.config.raw_css == [pre_raw_css]
+    assert pn.config.js_files == {"somejs": pre_js}
+    assert pn.config.css_files == backup_css_files


### PR DESCRIPTION
The purpose of the `TemporaryResources` context manager is to enable using temporary,
specific configuration of resources when creating a custom Template.

If you use the global configuration `pn.config` for your templates you will include the same
css and js files in all templates. This is problematic if you want different templates,
like for example a light template, a dark template, a bootstrap template, a material
template, a template with Plotly Plots, and template without Plotly plots etc.

```bash
Args:
    extensions (Optional[Set], optional): Custom pn.extensions like. For example {'plotly'}.
        Defaults to None.
    raw_css (Optional[List], optional): Corresponds to pn.config.raw_css.
        Defaults to None.
    css_files (Optional[List], optional): Corresponds to pn.config.css_files.
        Defaults to None.
    js_files (Optional[Dict], optional): Corresponds to pn.js_files. Defaults to None.
    include_panel_css (bool, optional): If False the Panel css is not included. You can use
        this if you wan't to create static pages without Panel functionality. The page will
        load quicker if the Panel css is not included, Defaults to True.
```

```python
>>> pn.config.raw_css = ["body {color: black}"]
>>> with TemporaryResources(raw_css=["body {color: white}"]):
...     temporary_raw_css = pn.config.raw_css
...     temporary_header = pn.io.resources.Resources().render()
>>> temporary_raw_css
['body {color: white}']
>>> pn.config.raw_css
['body {color: black}']
>>> "body {color: white}" in temporary_header
True
>>> "body {color: black}" in temporary_header
False
```

Please note that the `pn.io.resources.Resources().render` function is what is normally
used by Bokeh and Panel to render the resources (css+js) in the head of the template. Thus
by using the TemporaryResources context manager we can get specific resources in the head
of the template only.